### PR TITLE
Use key_encoded not key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: amplium/git-crypt-action@master
         with:
-          key: ${{ secrets.KEY }}
+          key_encoded: ${{ secrets.KEY }}
 ```


### PR DESCRIPTION
The instructions in the readme are to use the encoded key in GitHub secrets.