### PR TITLE
Mistake in the bash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this workflow, export your key and encode it with `base64`, then
 register it as a GitHub Secret.
 
 ```bash
-❯ git-crypt export-key - | base64
+❯ git-crypt export-key -- - | base64
 ```
 
 Finally, use it in your workflow.


### PR DESCRIPTION
I believe the correct command should be, `git-crypt export-key -- - | base64` as otherwise you get the following error; 

```
Error: no filename specified
Usage: git-crypt export-key [OPTIONS] FILENAME

    -k, --key-name KEYNAME      Export the given key, instead of the default

When FILENAME is -, export to standard out.
```